### PR TITLE
Add recipe support to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # anylist_cli
 
 An unofficial command-line utility for manage your
-[AnyList](https://www.anylist.com/) shopping lists, items, meal plans, stores, and categories.
+[AnyList](https://www.anylist.com/) shopping lists, items, recipes, meal plans, stores, and categories.
 
 ## Installation
 
@@ -116,6 +116,20 @@ anylist meal-plan update CALENDAR_ID EVENT_ID 2024-01-17 --title "Updated dinner
 anylist meal-plan delete CALENDAR_ID EVENT_ID
 ```
 
+### Recipes
+
+```bash
+# List all recipes
+anylist recipe list
+
+# View a specific recipe by name or ID
+anylist recipe get "Pasta Carbonara"
+anylist recipe get RECIPE_ID
+
+# Default: list all recipes
+anylist recipe
+```
+
 ## Getting Help
 
 Use `--help` with any command to see available options:
@@ -150,6 +164,7 @@ src/
     ├── items.rs         # Item management commands
     ├── stores.rs        # Store management commands
     ├── categories.rs    # Category management commands
+    ├── recipes.rs       # Recipe management commands
     └── meal_plans.rs    # Meal plan commands
 ```
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,5 +3,6 @@ pub mod items;
 pub mod list;
 pub mod login;
 pub mod meal_plans;
+pub mod recipes;
 pub mod stores;
 pub mod tail;

--- a/src/commands/recipes.rs
+++ b/src/commands/recipes.rs
@@ -1,0 +1,166 @@
+use anylist_rs::{AnyListClient, Ingredient, Recipe};
+use clap::{Arg, ArgMatches, Command};
+
+use crate::auth::read_tokens;
+use crate::error::CliError;
+
+fn display_recipe_list(recipes: Vec<Recipe>) {
+    if recipes.is_empty() {
+        println!("No recipes found.");
+        return;
+    }
+
+    println!("\nYour Recipes:");
+    println!("{}", "=".repeat(13));
+    println!();
+
+    // Sort recipes by name
+    let mut sorted = recipes;
+    sorted.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+
+    for recipe in sorted {
+        let ingredient_count = recipe.ingredients.len();
+        let step_count = recipe.preparation_steps.len();
+        print!("  \x1B[1m{}\x1B[0m", recipe.name);
+
+        if ingredient_count > 0 || step_count > 0 {
+            print!(" ({} ingredients, {} steps)", ingredient_count, step_count);
+        }
+
+        if let Some(rating) = recipe.rating {
+            let stars = "★".repeat(rating as usize);
+            print!(" {}", stars);
+        }
+
+        println!();
+    }
+    println!();
+}
+
+fn display_ingredient(ingredient: &Ingredient) {
+    print!("    • {}", ingredient.name);
+    if let Some(qty) = &ingredient.quantity {
+        print!(": {}", qty);
+    }
+    if let Some(note) = &ingredient.note {
+        print!(" ({})", note);
+    }
+    println!();
+}
+
+fn display_recipe_detail(recipe: &Recipe) {
+    println!("\n\x1B[1m{}\x1B[0m", recipe.name);
+    println!("{}", "=".repeat(recipe.name.len()));
+    println!();
+
+    // Display ID
+    println!("ID: {}", recipe.id);
+
+    // Display rating
+    if let Some(rating) = recipe.rating {
+        let stars = "★".repeat(rating as usize);
+        println!("Rating: {}", stars);
+    }
+
+    // Display source
+    if let Some(source_name) = &recipe.source_name {
+        print!("Source: {}", source_name);
+        if let Some(source_url) = &recipe.source_url {
+            print!(" ({})", source_url);
+        }
+        println!();
+    }
+
+    // Display servings
+    if let Some(servings) = &recipe.servings {
+        println!("Servings: {}", servings);
+    }
+
+    // Display times
+    if let Some(prep_time) = recipe.prep_time {
+        println!("Prep Time: {} minutes", prep_time);
+    }
+    if let Some(cook_time) = recipe.cook_time {
+        println!("Cook Time: {} minutes", cook_time);
+    }
+
+    // Display note
+    if let Some(note) = &recipe.note {
+        println!("\nNote: {}", note);
+    }
+
+    // Display ingredients
+    if !recipe.ingredients.is_empty() {
+        println!("\n\x1B[1mIngredients:\x1B[0m");
+        for ingredient in &recipe.ingredients {
+            display_ingredient(ingredient);
+        }
+    }
+
+    // Display preparation steps
+    if !recipe.preparation_steps.is_empty() {
+        println!("\n\x1B[1mPreparation:\x1B[0m");
+        for (i, step) in recipe.preparation_steps.iter().enumerate() {
+            println!("  {}. {}", i + 1, step);
+        }
+    }
+
+    println!();
+}
+
+pub fn command() -> Command {
+    Command::new("recipe")
+        .about("View and manage your AnyList recipes")
+        .long_about(
+            "View and manage your AnyList recipes.\n\n\
+             By default, this command shows all your recipes.\n\
+             Use subcommands to view recipe details.",
+        )
+        .subcommand(
+            Command::new("list")
+                .about("List all recipes")
+                .long_about("Display a list of all your recipes with ingredient and step counts"),
+        )
+        .subcommand(
+            Command::new("get")
+                .about("Display details for a specific recipe")
+                .arg(
+                    Arg::new("name")
+                        .help("Name or ID of the recipe to display")
+                        .required(true)
+                        .value_name("RECIPE_NAME_OR_ID"),
+                ),
+        )
+}
+
+pub async fn exec_command(matches: &ArgMatches) -> Result<(), CliError> {
+    let tokens = read_tokens()?;
+    let client = AnyListClient::from_tokens(tokens)?;
+
+    match matches.subcommand() {
+        Some(("list", _)) => {
+            let recipes = client.get_recipes().await?;
+            display_recipe_list(recipes);
+        }
+        Some(("get", sub_matches)) => {
+            let identifier = sub_matches
+                .get_one::<String>("name")
+                .expect("required argument");
+
+            // Try to get by name first, fall back to ID
+            let recipe = match client.get_recipe_by_name(identifier).await {
+                Ok(r) => r,
+                Err(_) => client.get_recipe_by_id(identifier).await?,
+            };
+
+            display_recipe_detail(&recipe);
+        }
+        _ => {
+            // Default: show all recipes
+            let recipes = client.get_recipes().await?;
+            display_recipe_list(recipes);
+        }
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ mod commands;
 mod error;
 
 use clap::Command;
-use commands::{categories, items, list, login, meal_plans, stores, tail};
+use commands::{categories, items, list, login, meal_plans, recipes, stores, tail};
 use error::CliError;
 use std::process;
 
@@ -19,7 +19,7 @@ async fn run() -> Result<(), CliError> {
     let matches = Command::new("anylist")
         .version(env!("CARGO_PKG_VERSION"))
         .author(env!("CARGO_PKG_AUTHORS"))
-        .about("Manage your AnyList shopping lists, items, meal plans, and more.")
+        .about("Manage your AnyList shopping lists, items, recipes, meal plans, and more.")
         .subcommand_required(true)
         .arg_required_else_help(true)
         .subcommand(login::command())
@@ -28,6 +28,7 @@ async fn run() -> Result<(), CliError> {
         .subcommand(stores::command())
         .subcommand(categories::command())
         .subcommand(meal_plans::command())
+        .subcommand(recipes::command())
         .subcommand(tail::command())
         .get_matches();
 
@@ -49,6 +50,9 @@ async fn run() -> Result<(), CliError> {
         }
         Some(("meal-plan", sub_matches)) => {
             meal_plans::exec_command(sub_matches).await?;
+        }
+        Some(("recipe", sub_matches)) => {
+            recipes::exec_command(sub_matches).await?;
         }
         Some(("tail", sub_matches)) => {
             tail::exec_command(sub_matches).await?;


### PR DESCRIPTION
Adds recipe viewing functionality to the CLI:
- New 'recipe list' command to view all recipes with ingredient/step counts
- New 'recipe get' command to view detailed recipe information by name or ID
- Displays recipe ingredients, preparation steps, ratings, cooking times, and more
- Updated README with recipe command examples and documentation

Resolves #1